### PR TITLE
added support for npm 5

### DIFF
--- a/bin/svn-modules-install.js
+++ b/bin/svn-modules-install.js
@@ -123,14 +123,6 @@ for (let moduleName of Object.keys(svnDependencies)) {
   }
 }
 
-// Delete local cache (svn_modules)
-try {
-  if (fs.existsSync(svnModulesPath))
-    rimraf.sync(svnModulesPath)
-} catch (err) {
-  logger.warn(`Unable to delete local cache`)
-}
-
 // Report summary of installation
 if (errorCount === 0 && successCount > 0) {
   logger.success('All SVN dependencies were installed successfully')


### PR DESCRIPTION
In version 5, npm creates only a symlink to the modules in the svn_modules folder instead of copying the whole modules into node_modules.

**Changed in this pull request**
The svn_modules directory won't be deleted anymore.